### PR TITLE
django-pipeline > 1.2.12 (I *think*) compatibility

### DIFF
--- a/pipeline_compass/compiler.py
+++ b/pipeline_compass/compiler.py
@@ -18,5 +18,5 @@ class CompassCompiler(CompilerBase):
   def match_file(self, filename):
     return filename.endswith('.scss')
 
-  def compile_file(self, content, path):
+  def compile_file(self, content, path, **kwargs):
     return scss.Scss().compile(content)


### PR DESCRIPTION
Some keyword arguments were added to CompilerBase.compile_file so I just added **kwargs to the function definition. It looks like github for windows decided to change the line endings or something, changing every line in the file, so you might just want to make the change manually and close this. Thanks for the code!
